### PR TITLE
Fix auth — no keys were sent

### DIFF
--- a/TrelloKit.podspec
+++ b/TrelloKit.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |spec|
   spec.frameworks = 'Foundation', 'UIKit'
   spec.source_files = 'TrelloKit/', 'TrelloKit/Models', 'TrelloKit/Extensions'
   spec.dependency 'MTDates', '1.0.2'
-  spec.dependency 'AFNetworking', '~> 2.5.0'
+  spec.dependency 'AFNetworking/NSURLSession', '~> 2.5.0'
 end

--- a/TrelloKit/TrelloHTTPClient.h
+++ b/TrelloKit/TrelloHTTPClient.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 Scott Petit. All rights reserved.
 //
 
-#import <AFNetworking/AFNetworking.h>
+#import <AFNetworking/AFHTTPSessionManager.h>
 
 typedef void (^TrelloHTTPClientSuccess)(NSURLSessionDataTask *response, id responseObject);
 typedef void (^TrelloHTTPClientFailure)(NSURLSessionDataTask *task, NSError *error);


### PR DESCRIPTION
Good you've updated AFNetworking dependency. :+1: 
Unfortunately, `- requestWithMethod:path:parameters:` does not exist on newer TrelloHTTPClient's superclass thus it does not get called. Replaced with other one, it's private, so I defined it in `TrelloHTTPClient` to be visible — not a very good idea but it quickly fixes broken functionality. 

Anso I narrowed dependencies a bit.
