### PR TITLE
Fixed card members parsing

### DIFF
--- a/TrelloKit/Models/TRLCard.m
+++ b/TrelloKit/Models/TRLCard.m
@@ -31,7 +31,7 @@
         _closed = [dictionary[@"closed"] boolValue];
         _position = [dictionary[@"pos"] integerValue];
         _url = [[NSURL URLWithString:[dictionary trello_safeObjectForKey:@"url"]] copy];
-        _memberIdentifiers = [dictionary trello_safeObjectForKey:@"members"];
+        _memberIdentifiers = [dictionary trello_safeObjectForKey:@"idMembers"];
         
         NSArray *labelsArray = [dictionary trello_safeObjectForKey:@"labels"];
         NSMutableArray *mutableLabels = [NSMutableArray arrayWithCapacity:labelsArray.count];


### PR DESCRIPTION
Field now called `idMembers`, not `members`
